### PR TITLE
Provided an option to disable the resolving of local paths for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ grunt.initConfig({
       dest: "css/output.css",
       options: {
         skipExternal: true,
+        resolvePath: true,
         rewriteUrl: function(url, options, dataURI) {
           var path = url.replace(options.baseDir, '');
           var hash = require('crypto').createHash('md5').update(dataURI).digest('hex');
@@ -116,6 +117,7 @@ CssUrlRewrite can be customized by specifying the following options:
 * `baseDir`: If you have absolute image paths in your stylesheet, the path specified in this option will be used as the base directory.
 * `stripParameters`: Remove querystring-parameters from url's.
 * `skipExternal`: Skip external url's. Rewriting external url's doesn't always work yet, so this could be necessary for good results.
+* `resolvePath`: If set to true, it will automatically resolve the local path to each URL. In windows environments, set this to false.
 
 ### Skipping Images
 

--- a/tasks/lib/encode.js
+++ b/tasks/lib/encode.js
@@ -100,17 +100,20 @@ exports.init = function(grunt) {
           is_local_file = !rData.test(img) && !rExternal.test(img);
 
         // Resolve the image path relative to the CSS file
-        if(is_local_file) {
-          // local file system.. fix up the path
-          loc = img.charAt(0) === "/" ?
-            (opts.baseDir || "") + loc :
-            path.join(path.dirname(srcFile),  (opts.baseDir || "") + img);
+        // (@egpierro) provide an option to disable this, because it does not work well on windows envs
+        if(opts.resolvePath) {
+            if (is_local_file) {
+                // local file system.. fix up the path
+                loc = img.charAt(0) === "/" ?
+                    (opts.baseDir || "") + loc :
+                    path.join(path.dirname(srcFile), (opts.baseDir || "") + img);
 
-          // If that didn't work, try finding the image relative to
-          // the current file instead.
-          if(!fs.existsSync(loc)) {
-            loc = path.resolve(__dirname + img);
-          }
+                // If that didn't work, try finding the image relative to
+                // the current file instead.
+                if (!fs.existsSync(loc)) {
+                    loc = path.resolve(__dirname + img);
+                }
+            }
         }
 
         exports.image(loc, opts, function(err, resp) {


### PR DESCRIPTION
For some reason when running this on Windows envs, grunt will abort with warnings like below example:

```
Warning: File C:\Users\e.j.garcia\Developer\handlebars-poc\node_modules\grunt-css-url-rewrite\tasks\lib\JFP\css\common\JPPWidget.css does not exist Use --force to continue.
```

I added an attribute `resolvePath` to disable lines 103 to 113 on `encode.js`
