### PR TITLE
fix that replaces \ separator by /

### DIFF
--- a/tasks/lib/encode.js
+++ b/tasks/lib/encode.js
@@ -104,7 +104,7 @@ exports.init = function(grunt) {
           // local file system.. fix up the path
           loc = img.charAt(0) === "/" ?
             (opts.baseDir || "") + loc :
-            path.join(path.dirname(srcFile),  (opts.baseDir || "") + img);
+            path.join(path.dirname(srcFile),  (opts.baseDir || "") + img).replace(/\\/g, '/');
 
           // If that didn't work, try finding the image relative to
           // the current file instead.


### PR DESCRIPTION
Fix for Windows : paths generated by path.join contain "\" characters, which won't work in CSS files. This fixes this issue.
