### PR TITLE
new parallel option

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ CssUrlRewrite can be customized by specifying the following options:
 * `baseDir`: If you have absolute image paths in your stylesheet, the path specified in this option will be used as the base directory.
 * `stripParameters`: Remove querystring-parameters from url's.
 * `skipExternal`: Skip external url's. Rewriting external url's doesn't always work yet, so this could be necessary for good results.
+* `parallel`: true to execute the rewrite asynchronously for each file. Default value is true.
 
 ### Skipping Images
 

--- a/tasks/grunt-image-embed.js
+++ b/tasks/grunt-image-embed.js
@@ -20,7 +20,7 @@ module.exports = function(grunt) {
 
   grunt.registerMultiTask("cssUrlRewrite", "Rewrite URIs inside your stylesheets", function() {
     var opts = this.options();
-    var done = this.async();
+    var done = opts.parallel === false ? function() {} : this.async();
 
     var filesRemaining = this.files.length;
 
@@ -35,15 +35,23 @@ module.exports = function(grunt) {
         };
       });
 
-      // Once all files have been processed write them out.
-      async.parallel(tasks, function(err, output) {
+      // Once all files have been processed write them out.	  
+      var cb = function(err, output) {
         grunt.file.write(dest, output);
         grunt.log.writeln('File "' + dest + '" created.');
         filesRemaining--;
         if (filesRemaining === 0) {
           done();
         }
-      });
+      };
+      if (opts.parallel === false) {
+        grunt.util._.each(tasks, function(task) {
+          task(cb);
+        });
+      } else {
+        // Once all files have been processed write them out.
+        async.parallel(tasks, cb);
+      }
     });
   });
 


### PR DESCRIPTION
When using a grunt task like grunt-contrib-watch, the call to done() stops terminates grunt, and therefore the watch task.

A solution would be to not execute the rewrites using async.parallel, but in an iteartive way, despite it being less optimized.

The "parallel" option can be used to do just that.

Since the best way is still using async.parallel, the default value of "parallel" is 'true'.
