### PR TITLE
Fix path joins in encode file.

### DIFF
--- a/tasks/lib/encode.js
+++ b/tasks/lib/encode.js
@@ -103,13 +103,13 @@ exports.init = function(grunt) {
         if(is_local_file) {
           // local file system.. fix up the path
           loc = img.charAt(0) === "/" ?
-            (opts.baseDir || "") + loc :
-            path.join(path.dirname(srcFile),  (opts.baseDir || "") + img).replace(/\\/g, '/');
+            path.josin((opts.baseDir || ""), loc) :
+            path.join(path.dirname(srcFile),  (opts.baseDir || ""), img).replace(/\\/g, '/');
 
           // If that didn't work, try finding the image relative to
           // the current file instead.
           if(!fs.existsSync(loc)) {
-            loc = path.resolve(__dirname + img);
+            loc = path.resolve(path.join(__dirname, img));
           }
         }
 


### PR DESCRIPTION
This plugin does not work properly with its paths.

Paths should not be joined by concatenating strings: (back)slashes will go missing. path.join also correctly handles double slashes.
